### PR TITLE
Fix Firefox mime type compatibility issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # MyExcel
 
+> NOTE: This repository has been forked from the original to include [this yet-to-be merged bug fix](https://github.com/healthcarelogic/MyExcel/pull/1). Once the bug has been fixed in the original repository, this one may be closed. Currently depended on by [sähkönumerot.fi](https://github.com/by-pinja/sahkonumerot-fi).
+
 ## npm
 
 * Install

--- a/myexcel.js
+++ b/myexcel.js
@@ -718,7 +718,7 @@ var $JExcel = {};
             zip.file('[Content_Types].xml', sheets.toContentType());                                            // Add content types
             sheets.fileData(xl);                                                                                // Zip the rest
             // And generate !!!
-            zip.generateAsync({ type: "blob", mimeType: "application/vnd.ms-excel" })
+            zip.generateAsync({ type: "blob", mimeType: "application/vnd.ms-excel,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet" })
                 .then(function (content) { saveAs(content, filename); })
                 .then(callbackFunc);
         }


### PR DESCRIPTION
The current implementation is not compatible with Firefox. Extends mime type support to XLSX files to fix this issue.
See the original PR here: https://github.com/josesegarra/MyExcel/pull/23